### PR TITLE
Fixed discrepancy with BCML format

### DIFF
--- a/src/botw/mod.rs
+++ b/src/botw/mod.rs
@@ -458,7 +458,7 @@ impl Control {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-#[serde(rename_all = "snake_case", tag = "type")]
+#[serde(rename_all = "snake_case")]
 pub enum RawControl {
     Zero(self::zero::Control0),
     One(self::one::Control1),


### PR DESCRIPTION
I found a mod in the wild that uses the `RawControl` feature in its custom text replacements. The format used in that file is accepted by BCML, but rejected by this library because the `serde` encoding doesn't match the real structure. This one-line change would make UKMM compatible with these mods again.

I realize there could be hurdles to this: as this seems to be a general library for a general file format, it could break other applications which currently (knowing or not) rely on the old behavior. In this case the better solution might be a custom handler to deserialize both versions when needed. If this fork is really meant to just be used by UKMM that probably wouldn't actually be an issue, but as I assume the error is also present upstream it might be worth thinking about.